### PR TITLE
Bluedot SDK updated for 15.4.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -59,7 +59,7 @@
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="BluedotPointSDK" spec="~> 15.5.1" />
+                <pod name="BluedotPointSDK" spec="~> 15.6.0" />
             </pods>
         </podspec>
     </platform>

--- a/src/android/bluedotplugin.gradle
+++ b/src/android/bluedotplugin.gradle
@@ -6,5 +6,5 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.gitlab.bluedotio.android:point_sdk_android:15.3.5'
+    implementation 'com.gitlab.bluedotio.android:point_sdk_android:15.4.0'
 }


### PR DESCRIPTION
Can be tested using MinApp https://github.com/Bluedot-Innovation/Bluedot-Cordova-Minimal-Integration/tree/dev/update-plugin-4.0.0
Update the dependencies in `package.json` to use branch `ni/15.4.0`
as:
 "@bluedot-innovation/cordova-plugin": "git+https://github.com/Bluedot-Innovation/PointSDK-Plugin-Cordova.git#ni/15.4.0"


Plugin updated for Android 15.4.0 and iOS 15.6.0, both Android and iOS Min app can be tested